### PR TITLE
feat(Docker): expose a REMAIN_X_FORWARD_HEADERS option

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,8 +1,8 @@
 CONFIG_PATH=/config
 PORT=3000
 QBIT_BASE=http://host.docker.internal:8080
-REMAIN_X_FORWARD_HEADERS=false
 RELEASE_TYPE=stable
 UPDATE_VT_CRON=0 * * * *
 USE_INSECURE_SSL=false
+SKIP_X_FORWARD_HEADERS=false
 VUETORRENT_PATH=/vuetorrent

--- a/.env.dist
+++ b/.env.dist
@@ -1,6 +1,7 @@
 CONFIG_PATH=/config
 PORT=3000
 QBIT_BASE=http://host.docker.internal:8080
+REMAIN_X_FORWARD_HEADERS=false
 RELEASE_TYPE=stable
 UPDATE_VT_CRON=0 * * * *
 USE_INSECURE_SSL=false

--- a/docker-compose.gluetun.yml
+++ b/docker-compose.gluetun.yml
@@ -57,6 +57,6 @@ services:
       # Only enable if using self-signed certificates
       # - USE_INSECURE_SSL=true
       # Only enable if backend container is behind a proxy server which already add x-forward headers
-      # - REMAIN_X_FORWARD_HEADERS=true
+      # - SKIP_X_FORWARD_HEADERS=true
     volumes:
       - "./data/config:/config"

--- a/docker-compose.gluetun.yml
+++ b/docker-compose.gluetun.yml
@@ -56,5 +56,7 @@ services:
       - UPDATE_VT_CRON=0 * * * *
       # Only enable if using self-signed certificates
       # - USE_INSECURE_SSL=true
+      # Only enable if backend container is behind a proxy server which already add x-forward headers
+      # - REMAIN_X_FORWARD_HEADERS=true
     volumes:
       - "./data/config:/config"

--- a/docker-compose.simple.yml
+++ b/docker-compose.simple.yml
@@ -39,7 +39,7 @@ services:
       # Only enable if using self-signed certificates
       # - USE_INSECURE_SSL=true
       # Only enable if backend container is behind a proxy server which already add x-forward headers
-      # - REMAIN_X_FORWARD_HEADERS=true
+      # - SKIP_X_FORWARD_HEADERS=true
     ports:
       - "8080:8080"
     volumes:

--- a/docker-compose.simple.yml
+++ b/docker-compose.simple.yml
@@ -38,6 +38,8 @@ services:
       - UPDATE_VT_CRON=0 * * * *
       # Only enable if using self-signed certificates
       # - USE_INSECURE_SSL=true
+      # Only enable if backend container is behind a proxy server which already add x-forward headers
+      # - REMAIN_X_FORWARD_HEADERS=true
     ports:
       - "8080:8080"
     volumes:

--- a/src/routers/qbit/index.js
+++ b/src/routers/qbit/index.js
@@ -6,7 +6,7 @@ const router = Router()
 router.use((req, res, next) => {
   const proxy = httpProxy.createProxyServer({
     host: process.env.QBIT_BASE,
-    xfwd: true,
+    xfwd: process.env.REMAIN_X_FORWARD_HEADERS !== 'true',
     secure: process.env.USE_INSECURE_SSL !== 'true',
   })
   proxy.web(req, res, { target: `${process.env.QBIT_BASE}/api` }, next)

--- a/src/routers/qbit/index.js
+++ b/src/routers/qbit/index.js
@@ -6,7 +6,7 @@ const router = Router()
 router.use((req, res, next) => {
   const proxy = httpProxy.createProxyServer({
     host: process.env.QBIT_BASE,
-    xfwd: process.env.REMAIN_X_FORWARD_HEADERS !== 'true',
+    xfwd: process.env.SKIP_X_FORWARD_HEADERS !== 'true',
     secure: process.env.USE_INSECURE_SSL !== 'true',
   })
   proxy.web(req, res, { target: `${process.env.QBIT_BASE}/api` }, next)


### PR DESCRIPTION
I have a proxy server that already add x-forward headers and it is in front of backend container. 

If xfwd is enabled in http-proxy,  http-proxy will overwrite x-forward  headers. When I login qbit via backend container, the log related to web login ip will show the proxy server ip. It is not correct.

Maybe, qbit cannot recognize IPs in x-forward headers, so I want to disable xfwd to make it correct in my scenario. 


Related things:
1. https://github.com/http-party/node-http-proxy/blob/master/lib/http-proxy/passes/web-incoming.js#L68
2. https://github.com/http-party/node-http-proxy/issues/1159#issuecomment-339502323