### PR TITLE
fix(auth): support qBittorrent SID cookies

### DIFF
--- a/src/middlewares/auth.js
+++ b/src/middlewares/auth.js
@@ -6,18 +6,27 @@ export default async function authMiddleware(req, res, next) {
   }
   const { cookies } = req
   const { SID } = cookies
+  const port = process.env.PORT || '8080'
+  const expectedQbtSid = `QBT_SID_${port}`
+  const qbtSidName = Object.keys(cookies || {}).find(k => k === expectedQbtSid) || Object.keys(cookies || {}).find(k => /^QBT_SID_\d+$/.test(k))
+  const effectiveSid = SID || (qbtSidName ? cookies[qbtSidName] : undefined)
+  const effectiveSidName = SID ? 'SID' : qbtSidName
 
-  if (await isValidSID(SID)) {
+  if (!effectiveSid) {
+    return res.status(401).json({ error: 'Unauthorized' })
+  }
+
+  if (await isValidSID(effectiveSidName, effectiveSid)) {
     next()
   } else {
     res.status(401).json({ error: 'Unauthorized' })
   }
 }
 
-async function isValidSID(SID) {
+async function isValidSID(cookieName, SID) {
   const headers = {}
-  if (SID) {
-    headers['Cookie'] = `SID=${ SID }`
+  if (cookieName && SID) {
+    headers['Cookie'] = `${ cookieName }=${ SID }`
   }
 
   try {

--- a/src/middlewares/auth.js
+++ b/src/middlewares/auth.js
@@ -6,8 +6,16 @@ export default async function authMiddleware(req, res, next) {
   }
   const { cookies } = req
   const { SID } = cookies
-  const port = process.env.PORT || '8080'
-  const expectedQbtSid = `QBT_SID_${port}`
+  // derive qBittorrent WebUI port from QBIT_BASE (fallback to backend PORT)
+  const qbitBase = process.env.QBIT_BASE || 'http://localhost:8080'
+  let qbitPort
+  try {
+    const u = new URL(qbitBase)
+    qbitPort = u.port || (u.protocol === 'https:' ? '443' : '80')
+  } catch (e) {
+    qbitPort = process.env.PORT || '8080'
+  }
+  const expectedQbtSid = `QBT_SID_${qbitPort}`
   const qbtSidName = Object.keys(cookies || {}).find(k => k === expectedQbtSid) || Object.keys(cookies || {}).find(k => /^QBT_SID_\d+$/.test(k))
   const effectiveSid = SID || (qbtSidName ? cookies[qbtSidName] : undefined)
   const effectiveSidName = SID ? 'SID' : qbtSidName


### PR DESCRIPTION
Handle qBittorrent session cookies whose name depends on the WebUI port (for example QBT_SID_8090). This lets the backend validate and forward the correct cookie name instead of assuming SID or a fixed port.

Adresses #151


Before : 
<img width="2936" height="1608" alt="CleanShot 2026-05-14 at 00 28 54@2x" src="https://github.com/user-attachments/assets/472651f0-02bc-41d5-9a60-469b1a61b7ec" />


After :
<img width="2854" height="1608" alt="CleanShot 2026-05-14 at 01 19 28@2x" src="https://github.com/user-attachments/assets/3dd4f6de-715d-40be-9a52-c0769b6a70a0" />
